### PR TITLE
Disable %check phase for riscv64 builds

### DIFF
--- a/src/albs_build_lib/builder/mock/supervisor.py
+++ b/src/albs_build_lib/builder/mock/supervisor.py
@@ -230,6 +230,10 @@ class MockSupervisor():
             config_params.append(
                 'config_opts["macros"]["%_host_cpu"] = "ppc64le"\n'
             )
+        if self.__host_arch == 'riscv64':
+            config_params.append(
+                'config_opts["macros"]["%__spec_check_template"] = "exit 0; "\n'
+            )
         config_path = os.path.join(self.__storage_dir, 'site-defaults.cfg')
         self.__log.info(
             'generating site-defaults.cfg in the %s directory',


### PR DESCRIPTION
## Summary
- Add `%__spec_check_template` macro override for riscv64 architecture in mock site-defaults config
- This skips the `%check` phase for riscv64 builds, similar to the existing `%_host_cpu` macro for ppc64le

## Test plan
- [ ] Verify riscv64 mock builds skip the `%check` phase
- [ ] Verify ppc64le and other architectures are unaffected