### PR TITLE
Add shared_cache_key to MockConfig and keepcache/metadata_expire to YumConfig

### DIFF
--- a/src/albs_build_lib/builder/mock/mock_config.py
+++ b/src/albs_build_lib/builder/mock/mock_config.py
@@ -108,6 +108,7 @@ class MockConfig():
         yum_config=None,
         basedir=None,
         cachedir=None,
+        shared_cache_key=None,
         **kwargs,
     ):
         """
@@ -137,6 +138,10 @@ class MockConfig():
             Yum configuration.
         basedir : str, optional
             Mock basedir if want to override the default one (/var/lib/mock/).
+        shared_cache_key : str, optional
+            When set, configures yum_cache plugin to share the package
+            cache across mock configs with the same key (e.g.
+            'almalinux-kitten-10-x86_64').
 
         Raises
         ------
@@ -169,6 +174,7 @@ class MockConfig():
             'cache_topdir': cachedir,
         }
         self.__config_opts.update(**kwargs)
+        self.__shared_cache_key = shared_cache_key
         self.__append_config_opts = collections.defaultdict(list)
         self.__files = {}
         if files:
@@ -415,6 +421,13 @@ class MockConfig():
                     )
             for plugin in self.__plugins.values():
                 fd.write(plugin.render_config())
+            if self.__shared_cache_key:
+                fd.write(
+                    'config_opts["plugin_conf"]["yum_cache_opts"]'
+                    '["cache_key"] = {}\n'.format(
+                        to_mock_config_string(self.__shared_cache_key)
+                    )
+                )
             if self.__yum_config:
                 fd.write(self.__yum_config.render_config())
             for chroot_file in self.__files.values():

--- a/src/albs_build_lib/builder/mock/yum_config.py
+++ b/src/albs_build_lib/builder/mock/yum_config.py
@@ -22,11 +22,12 @@ class BaseYumConfig():
                 'best',
                 'enabled',
                 'gpgcheck',
+                'keepcache',
                 'obsoletes',
                 'module_hotfixes',
             ):
                 cfg.set(section, key, BaseYumConfig.render_bool_option(value))
-            elif key in ('debuglevel', 'retries'):
+            elif key in ('debuglevel', 'metadata_expire', 'retries'):
                 cfg.set(section, key, str(value))
             elif key == 'syslog_device':
                 cfg.set(section, key, value.strip())
@@ -117,6 +118,8 @@ class YumConfig(BaseYumConfig):
         repositories=None,
         module_platform_id=None,
         best=None,
+        keepcache=None,
+        metadata_expire=None,
     ):
         """
         Yum configuration initialization.


### PR DESCRIPTION
## Summary
- Add `shared_cache_key` as a first-class `MockConfig` parameter that renders `config_opts["plugin_conf"]["yum_cache_opts"]["cache_key"]` directly in `dump_to_file`, without resetting existing plugin options
- Add `keepcache` and `metadata_expire` as optional `YumConfig` parameters for per-platform yum caching control

Fixes AlmaLinux/build-system#527

## Test plan
- [ ] Verify `shared_cache_key` produces the correct `plugin_conf` line in mock.cfg
- [ ] Verify no `yum_cache_opts = {}` reset line is generated
- [ ] Verify `keepcache` and `metadata_expire` appear in rendered yum.conf when set
- [ ] Verify omitting `shared_cache_key` produces no change to existing behavior