### PR TITLE
Add NUMA-aware CPU pinning for build threads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "albs-build-lib"
-version = "0.1.8"
+version = "0.1.9"
 description = "Build System Builder Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/albs_build_lib/builder/base_thread_slave_builder.py
+++ b/src/albs_build_lib/builder/base_thread_slave_builder.py
@@ -9,6 +9,8 @@ import threading
 
 from albs_common_lib.utils.file_utils import clean_dir
 
+from albs_build_lib.builder.numa import apply_cpu_affinity
+
 
 class BaseSlaveBuilder(threading.Thread):
     """Build thread."""
@@ -16,6 +18,7 @@ class BaseSlaveBuilder(threading.Thread):
     def __init__(
         self,
         thread_num,
+        numa_cpus=None,
     ):
         """
         Build thread initialization.
@@ -30,8 +33,31 @@ class BaseSlaveBuilder(threading.Thread):
             Shows, if process got "kill -15" signal.
         graceful_terminated_event : threading.Event
             Shows, if process got "kill -10" signal.
+        numa_cpus : list of int, optional
+            CPU identifiers the thread should be pinned to. When provided,
+            ``apply_numa_affinity`` confines the thread (and the processes it
+            spawns) to these CPUs so that a build stays on a single NUMA node.
         """
         super().__init__(name='Builder-{0}'.format(thread_num))
+        self._numa_cpus = numa_cpus
+
+    def apply_numa_affinity(self):
+        """
+        Pins the running thread to the configured NUMA CPU set.
+
+        Must be called from inside ``run()`` so that the affinity is applied
+        to the build thread itself rather than the thread that constructed
+        the builder. Subprocesses spawned afterwards inherit the mask.
+        """
+        if not self._numa_cpus:
+            return
+        applied = apply_cpu_affinity(self._numa_cpus)
+        if applied:
+            logging.info(
+                '%s pinned to CPUs %s',
+                self.name,
+                sorted(applied),
+            )
 
     @staticmethod
     def init_working_dir(working_dir):

--- a/src/albs_build_lib/builder/numa.py
+++ b/src/albs_build_lib/builder/numa.py
@@ -1,0 +1,113 @@
+"""
+NUMA topology discovery and CPU affinity helpers.
+"""
+
+
+import logging
+import os
+import typing
+from pathlib import Path
+
+
+NODE_ROOT = Path('/sys/devices/system/node')
+
+
+def parse_cpulist(cpulist):
+    """
+    Parses a Linux cpulist string (e.g. "0-3,8,10-11") into a list of CPU ids.
+
+    Parameters
+    ----------
+    cpulist : str
+        Contents of a sysfs ``cpulist`` file.
+
+    Returns
+    -------
+    list of int
+        CPU identifiers contained in the list.
+    """
+    cpus = []
+    for part in cpulist.strip().split(','):
+        if not part:
+            continue
+        if '-' in part:
+            start, end = part.split('-')
+            cpus.extend(range(int(start), int(end) + 1))
+        else:
+            cpus.append(int(part))
+    return cpus
+
+
+def numa_nodes():
+    """
+    Discovers NUMA nodes that have CPUs assigned to them.
+
+    Reads ``/sys/devices/system/node/node*/cpulist`` and returns a mapping of
+    NUMA node id to the list of CPU ids belonging to that node. Nodes without
+    CPUs (memory-only nodes) are skipped. Returns an empty dictionary on hosts
+    where the sysfs NUMA hierarchy is not exposed (non-NUMA kernels,
+    restricted containers).
+
+    Note that NUMA node ids are not necessarily contiguous: ppc64le hosts
+    commonly expose ids such as 0 and 8.
+
+    Returns
+    -------
+    dict of int to list of int
+        Mapping of NUMA node id to its CPU ids, ordered by numeric node id.
+    """
+    if not NODE_ROOT.exists():
+        return {}
+    nodes = {}
+    paths = sorted(
+        NODE_ROOT.glob('node[0-9]*'),
+        key=lambda p: int(p.name[4:]),
+    )
+    for path in paths:
+        try:
+            cpulist = (path / 'cpulist').read_text()
+        except OSError:
+            continue
+        cpus = parse_cpulist(cpulist)
+        if cpus:
+            nodes[int(path.name[4:])] = cpus
+    return nodes
+
+
+def apply_cpu_affinity(cpus):
+    """
+    Pins the calling thread to the given set of CPUs.
+
+    The affinity mask is inherited by child processes, so subprocesses spawned
+    by the calling thread (e.g. ``mock``) are confined to the same CPUs. The
+    requested set is intersected with the thread's current affinity mask in
+    order to respect cgroup or taskset restrictions imposed by the operating
+    environment.
+
+    Parameters
+    ----------
+    cpus : list of int
+        CPU identifiers to pin the calling thread to. A falsy value is
+        treated as a no-op.
+
+    Returns
+    -------
+    set of int or None
+        The CPU set that was actually applied, or ``None`` if no affinity was
+        set (input was empty or no CPUs remained after intersecting with the
+        current mask).
+    """
+    if not cpus:
+        return None
+    allowed = os.sched_getaffinity(0)
+    effective = set(cpus) & allowed
+    if not effective:
+        logging.warning(
+            'NUMA CPU set %s has no overlap with current affinity %s, '
+            'skipping pinning',
+            sorted(cpus),
+            sorted(allowed),
+        )
+        return None
+    os.sched_setaffinity(0, effective)
+    return effective


### PR DESCRIPTION
## Summary
- New `builder/numa.py` reads NUMA topology from `/sys/devices/system/node/` and exposes `numa_nodes()`, `parse_cpulist()`, and `apply_cpu_affinity()`.
- `BaseSlaveBuilder` accepts an optional `numa_cpus` kwarg and exposes `apply_numa_affinity()` so subclasses can pin the build thread (and the mock processes it spawns) to a single NUMA node.
- No-op when `numa_cpus` is unset or the requested CPUs do not overlap the thread's current affinity, so existing callers are unaffected.
- Bumps version to 0.1.9.

## Test plan
- [ ] Verify `numa_nodes()` enumerates nodes correctly on x86_64 (contiguous ids) and ppc64le (non-contiguous ids such as 0 and 8).
- [ ] Verify a builder constructed without `numa_cpus` behaves exactly as before.
- [ ] Verify a builder constructed with `numa_cpus=[...]` applies the mask in `run()` and that mock processes inherit it (`taskset -p <mock-pid>`).
- [ ] Verify cgroup-restricted environments do not crash: the requested set is intersected with the current affinity, and a warning is logged when there is no overlap.